### PR TITLE
Change GH-install description from released to devel

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -39,7 +39,7 @@ You can install the released version of strex from [CRAN](https://CRAN.R-project
 install.packages("strex")
 ```
 
-You can install the released version of strex from [GitHub](https://github.com/rorynolan/strex/) with:
+You can install the development version of strex from [GitHub](https://github.com/rorynolan/strex/) with:
 
 ```{r, eval=FALSE}
 devtools::install_github("rorynolan/strex")

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can install the released version of strex from
 install.packages("strex")
 ```
 
-You can install the released version of strex from
+You can install the development version of strex from
 [GitHub](https://github.com/rorynolan/strex/) with:
 
 ``` r

--- a/index.Rmd
+++ b/index.Rmd
@@ -26,7 +26,7 @@ You can install the released version of strex from [CRAN](https://CRAN.R-project
 install.packages("strex")
 ```
 
-You can install the released version of strex from [CRAN](https://CRAN.R-project.org) with:
+You can install the development version of strex from [GitHub](https://github.com/rorynolan/strex/) with:
 
 ```{r, eval=FALSE}
 devtools::install_github("rorynolan/strex")

--- a/index.md
+++ b/index.md
@@ -24,8 +24,8 @@ You can install the released version of strex from
 install.packages("strex")
 ```
 
-You can install the released version of strex from
-[CRAN](https://CRAN.R-project.org) with:
+You can install the development version of strex from
+[GitHub](https://github.com/rorynolan/strex/) with:
 
 ``` r
 devtools::install_github("rorynolan/strex")


### PR DESCRIPTION
Great little package! 

Just made a minor change to the intro to installing from GitHub as development version (and fixed the link in index.Rmd—looks like you already got it in README.Rmd).