### PR TITLE
Fix for dev version of stringr

### DIFF
--- a/R/trim.R
+++ b/R/trim.R
@@ -32,9 +32,9 @@ str_trim_anything <- function(string, pattern, side = "both") {
   checkmate::assert_string(side)
   side %<>% match_arg(c("both", "left", "right"), ignore_case = TRUE)
   type <- "regex"
-  if (all(c("fixed", "pattern") %in% class(pattern))) {
+  if (inherits(pattern, "fixed") || inherits(pattern, "stringr_fixed")) {
     type <- "fixed"
-  } else if (all(c("coll", "pattern") %in% class(pattern))) {
+  } else if (inherits(pattern, "coll") || inherits(pattern, "stringr_coll")) {
     type <- "coll"
   } else {
     bad_starts <- str_starts(pattern, "\\(*\\^")

--- a/R/utils.R
+++ b/R/utils.R
@@ -140,12 +140,12 @@ verify_string_pattern <- function(string, pattern, boundary_allowed = TRUE) {
   checkmate::assert_character(string, min.len = 1)
   checkmate::assert_flag(boundary_allowed)
   if (boundary_allowed) {
-    if (all(c("boundary", "pattern") %in% class(pattern))) {
+    if (inherits(pattern, "boundary") || inherits(pattern, "stringr_boundary")) {
       checkmate::assert_character(pattern, min.len = 0)
     } else {
       checkmate::assert_character(pattern, min.len = 1)
     }
-  } else if (all(c("boundary", "pattern") %in% class(pattern))) {
+  } else if (inherits(pattern, "boundary") || inherits(pattern, "stringr_boundary")) {
     custom_stop("Function cannot handle a `pattern` of type 'boundary'.")
   } else {
     checkmate::assert_character(pattern, min.len = 1)


### PR DESCRIPTION
The stringr pattern classes now use the `stringr_` prefix.